### PR TITLE
Revert "cpp: do not pass #error into output stream, warn about it and exit non-0"

### DIFF
--- a/src/cpp.c
+++ b/src/cpp.c
@@ -988,8 +988,8 @@ for (;;) {
 	} else if (np == pragmaloc) {		/* pragma */
 		while (*inp != '\n')		/* pass text */
 			p = cotoken(p);
-#ifdef EXIT_ON_ERROR
 	} else if (np == errorloc) {		/* error */
+#ifdef	EXIT_ON_ERROR
 		if (trulvl > 0) {
 			char ebuf[BUFFERSIZ];
 
@@ -1008,6 +1008,9 @@ for (;;) {
 			pperror(ebuf);
 			exit(exfail);
 		}
+#else
+		while (*inp != '\n')		/* pass text */
+			p = cotoken(p);
 #endif
 	} else if (np==lneloc) {/* line */
 		if (flslvl==0 && pflag==0) {


### PR DESCRIPTION
This reverts commit ee5767d8ae3d6170524b1e6d36c529ca23514e54.

This commit seems wrong.

With it, if you compile `cpp` without `EXIT_ON_ERROR` defined, `cpp` just doesn't understand `#error` at all and outputs things like this during a gate build:

```
.../usr/include/sys/asm_linkage.h: 102: undefined control
```

With `EXIT_ON_ERROR` set, a gate build fails with:

```
  sys/asm_linkage.h: 102: #error      "inconsistent shift constants"
```

I think it's wrong to have a switch with toggles between "#error not understood" and "#error acted upon" and we should revert to "#error passed through to output stream" (as per OmniOS and SmartOS today) and "#error acted upon" - and then we can work on making the latter work with a gate build.